### PR TITLE
Improvements for Standaloneusers My Account page

### DIFF
--- a/ext/standaloneusers/Civi/Standalone/Utils.php
+++ b/ext/standaloneusers/Civi/Standalone/Utils.php
@@ -20,7 +20,7 @@ class Utils {
       // remove hide menu
       $item['child'] = array_filter($item['child'], fn ($subitem) => ($subitem['attributes']['name'] !== 'Hide Menu'));
 
-      // My Account.
+      // Add My Account.
       $item['child'][] = [
         'attributes' => [
           'label' => ts('My Account'),
@@ -30,17 +30,6 @@ class Utils {
           'weight' => 2,
         ],
       ];
-      // add change password
-      $item['child'][] = [
-        'attributes' => [
-          'label' => ts('Change Password'),
-          'name' => 'Change Password',
-          'url' => 'civicrm/admin/user/password?reset=1',
-          'icon' => 'crm-i fa-keyboard',
-          'weight' => 3,
-        ],
-      ];
-
       return;
 
     }

--- a/ext/standaloneusers/ang/afformEditMyAccount.aff.html
+++ b/ext/standaloneusers/ang/afformEditMyAccount.aff.html
@@ -1,9 +1,6 @@
 <af-form ctrl="afform">
   <af-entity type="User" name="User1" label="User 1" actions="{create: false, update: true}" security="RBAC" url-autofill="1" data="{}" />
-  <div class="af-markup">
-    <p><a href="/civicrm/my-account">My Account</a></p>
-  </div>
-  <fieldset af-fieldset="User1" class="af-container" af-title="Account info">
+  <fieldset af-fieldset="User1" class="af-container">
     <div class="af-markup"></div>
     <af-field name="username" />
     <af-field name="uf_name" defn="{help_pre: 'Email used for password resets.', input_attrs: {placeholder: 'Leave blank to use the primary email from the selected contact'}}" />

--- a/ext/standaloneusers/ang/afformEditMyAccount.aff.html
+++ b/ext/standaloneusers/ang/afformEditMyAccount.aff.html
@@ -3,12 +3,12 @@
   <fieldset af-fieldset="User1" class="af-container">
     <div class="af-markup"></div>
     <af-field name="username" />
-    <af-field name="uf_name" defn="{help_pre: 'Email used for password resets.', input_attrs: {placeholder: 'Leave blank to use the primary email from the selected contact'}}" />
-    <af-field name="timezone" defn="{help_pre: 'Set the timezone of the user. Date and times will be shown in this timezone. You can also leave it empty to use the default system timezone (which is a server setting).', input_attrs: {placeholder: 'Server default timezone'}}" />
-    <af-field name="language" defn="{help_pre: 'Set the user interface language of this user. You can also leave it empty to use the default system language.', input_attrs: {placeholder: 'System default language'}}" />
+    <af-field name="uf_name" defn="{help_pre: 'Email used for password resets.'}" />
+    <af-field name="timezone" defn="{help_pre: 'Set your local timezone. Date and times will be shown in this timezone when you are logged in. You can also leave it empty to use the default system timezone (which is a server setting).', input_attrs: {placeholder: 'Server default timezone'}}" />
+    <af-field name="language" defn="{help_pre: 'Set your user interface language. You can also leave it empty to use the default system language.', input_attrs: {placeholder: 'System default language'}}" />
     <div class="af-container af-container-style-pane">
       <af-field name="roles" defn="{input_type: 'DisplayOnly', input_attrs: {}}" />
     </div>
   </fieldset>
-  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Save</button>
 </af-form>

--- a/ext/standaloneusers/ang/afformEditMyAccount.aff.php
+++ b/ext/standaloneusers/ang/afformEditMyAccount.aff.php
@@ -3,9 +3,9 @@ use CRM_Standaloneusers_ExtensionUtil as E;
 
 return [
   'type' => 'form',
-  'title' => E::ts('Edit my account'),
+  'title' => E::ts('Edit My Account'),
   'icon' => 'fa-user',
-  'server_route' => 'civicrm/user/edit',
+  'server_route' => 'civicrm/my-account/edit',
   'permission' => [
     'edit my contact',
   ],

--- a/ext/standaloneusers/ang/afsearchMyAccount.aff.html
+++ b/ext/standaloneusers/ang/afsearchMyAccount.aff.html
@@ -1,3 +1,3 @@
 <div af-fieldset="">
-  <crm-search-display-grid search-name="My_account" display-name="My_account" filters="{'contact_id': options.contact_id}"></crm-search-display-grid>
+  <crm-search-display-grid search-name="My_Account" display-name="My_Account" filters="{'contact_id': options.contact_id}"></crm-search-display-grid>
 </div>

--- a/ext/standaloneusers/ang/crmChangePassword.ang.php
+++ b/ext/standaloneusers/ang/crmChangePassword.ang.php
@@ -9,7 +9,7 @@ return [
   // 'css' => ['ang/crmQueueMonitor.css'],
   'partials' => ['ang/crmChangePassword'],
   'requires' => ['crmUi', 'crmUtil', 'api4'],
-  'basePages' => ['civicrm/admin/user/password'],
+  'basePages' => ['civicrm/my-account/password'],
   'exports' => [
     // Export the module as an [E]lement
     'crm-change-password' => 'E',

--- a/ext/standaloneusers/managed/SavedSearch_My_Account.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_My_Account.mgd.php
@@ -3,16 +3,16 @@ use CRM_Standaloneusers_ExtensionUtil as E;
 
 return [
   [
-    'name' => 'SavedSearch_My_account',
+    'name' => 'SavedSearch_My_Account',
     'entity' => 'SavedSearch',
     'cleanup' => 'unused',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'My_account',
-        'label' => E::ts('My account'),
-        'api_entity' => 'UFMatch',
+        'name' => 'My_Account',
+        'label' => E::ts('My Account'),
+        'api_entity' => 'User',
         'api_params' => [
           'version' => 4,
           'select' => [
@@ -20,6 +20,9 @@ return [
             'contact_id',
             'contact_id.display_name',
             'uf_name',
+            'username',
+            'timezone',
+            'language:label',
           ],
           'orderBy' => [],
           'where' => [
@@ -32,12 +35,12 @@ return [
           'groupBy' => [],
           'join' => [
             [
-              'Contact AS UFMatch_Contact_contact_id_01',
+              'Contact AS User_Contact_contact_id_01',
               'LEFT',
               [
                 'contact_id',
                 '=',
-                'UFMatch_Contact_contact_id_01.id',
+                'User_Contact_contact_id_01.id',
               ],
             ],
           ],
@@ -48,16 +51,16 @@ return [
     ],
   ],
   [
-    'name' => 'SavedSearch_My_account_SearchDisplay_My_account',
+    'name' => 'SavedSearch_My_Account_SearchDisplay_My_Account',
     'entity' => 'SearchDisplay',
     'cleanup' => 'unused',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'My_account',
-        'label' => E::ts('My account'),
-        'saved_search_id.name' => 'My_account',
+        'name' => 'My_Account',
+        'label' => E::ts('My Account'),
+        'saved_search_id.name' => 'My_Account',
         'type' => 'grid',
         'settings' => [
           'colno' => '2',
@@ -68,7 +71,6 @@ return [
             [
               'type' => 'field',
               'key' => 'contact_id.display_name',
-              'dataType' => 'String',
               'label' => E::ts('Contact'),
               'link' => [
                 'path' => '',
@@ -82,10 +84,30 @@ return [
             ],
             [
               'type' => 'field',
-              'key' => 'uf_name',
-              'dataType' => 'String',
+              'key' => 'username',
               'label' => E::ts('Username'),
               'break' => TRUE,
+              'editable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'uf_name',
+              'label' => E::ts('Password Reset Email'),
+              'break' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'timezone',
+              'label' => E::ts('Timezone'),
+              'break' => TRUE,
+              'empty' => E::ts('System default'),
+            ],
+            [
+              'type' => 'field',
+              'key' => 'language:label',
+              'label' => E::ts('Language'),
+              'break' => TRUE,
+              'empty' => E::ts('System default'),
             ],
             [
               'size' => '',
@@ -112,7 +134,7 @@ return [
                   'entity' => '',
                   'action' => '',
                   'join' => '',
-                  'target' => '',
+                  'target' => 'crm-popup',
                 ],
               ],
               'type' => 'buttons',

--- a/ext/standaloneusers/managed/SavedSearch_My_account.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_My_account.mgd.php
@@ -91,9 +91,9 @@ return [
               'size' => '',
               'links' => [
                 [
-                  'path' => '/civicrm/user/edit#?User1=[uf_id]',
-                  'icon' => 'fa-key',
-                  'text' => E::ts('Update account'),
+                  'path' => '/civicrm/my-account/edit#?User1=[uf_id]',
+                  'icon' => 'fa-user',
+                  'text' => E::ts('Update Account'),
                   'style' => 'default',
                   'condition' => [],
                   'task' => '',
@@ -103,9 +103,9 @@ return [
                   'target' => '',
                 ],
                 [
-                  'path' => '/civicrm/admin/user/password',
+                  'path' => '/civicrm/my-account/password',
                   'icon' => 'fa-keyboard',
-                  'text' => E::ts('Update password'),
+                  'text' => E::ts('Change Password'),
                   'style' => 'default',
                   'condition' => [],
                   'task' => '',

--- a/ext/standaloneusers/xml/Menu/standaloneusers.xml
+++ b/ext/standaloneusers/xml/Menu/standaloneusers.xml
@@ -7,12 +7,6 @@
     <access_arguments>*always allow*</access_arguments>
   </item>
   <item>
-    <path>civicrm/admin/user/password</path>
-    <page_callback>CRM_Standaloneusers_Page_ChangePassword</page_callback>
-    <title>Change Password</title>
-    <access_arguments>access CiviCRM</access_arguments>
-  </item>
-  <item>
     <path>civicrm/login/password</path>
     <page_callback>CRM_Standaloneusers_Page_ResetPassword</page_callback>
     <title>Reset Password</title>
@@ -29,5 +23,11 @@
     <page_callback>CRM_Standaloneusers_Page_TOTPSetup</page_callback>
     <title>Multi Factor Authentication: Set-up</title>
     <access_arguments>*always allow*</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/my-account/password</path>
+    <page_callback>CRM_Standaloneusers_Page_ChangePassword</page_callback>
+    <title>Change Password</title>
+    <access_arguments>access CiviCRM</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
Overview
----------------------------------------
- put My Account mgmt pages under `/civicrm/my-account` => nice breadcrumbs, and fixes https://lab.civicrm.org/dev/core/-/issues/5673 )
- remove separate Change Password link from top menu (awkward)
<img width="465" height="276" alt="image" src="https://github.com/user-attachments/assets/e5251765-d897-4a3e-ae00-b00e93e46a80" />

- show the same info on View My Account and Edit My Account (requires using the User entity rather than UFMatch which doesn't have Standalone extra goodies (like timezone))
- add correct Username field, correct label of User Email field
- use Edit My Account form rather than the standard User edit form (which many users wont have permissions for)